### PR TITLE
Add user management and basic logging

### DIFF
--- a/src/logger.js
+++ b/src/logger.js
@@ -1,0 +1,16 @@
+import { addDoc, collection, Timestamp } from 'firebase/firestore';
+import { db } from './firebase';
+
+export async function logUserAction(uid, accion, detalles = {}) {
+  try {
+    await addDoc(collection(db, 'logs'), {
+      uid,
+      accion,
+      detalles,
+      fecha: Timestamp.now()
+    });
+  } catch (err) {
+    console.error('Error al registrar accion', err);
+  }
+}
+


### PR DESCRIPTION
## Summary
- add logger utility to track user actions in Firestore
- add `Usuarios` and `Reportes` sections
- log main CRUD actions for vecinos, mascotas and atenciones
- allow exporting an activities report filtered by date range

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_687fdd0f4bd88326929ba6f5f5e69466