### PR TITLE
Add admin user and style login

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ cp .env.example .env
 
 Luego edite `.env` y coloque los valores proporcionados por Firebase.
 
+### Usuario administrador
+- Usuario: `admin`
+- Contraseña: `si2025`
+
 ## Available Scripts
 
 Dentro del directorio del proyecto se puede ejecutar:

--- a/src/App.js
+++ b/src/App.js
@@ -675,12 +675,17 @@ const App = () => {
     const handleSidebarSelect = (section) => {
         if (section === 'logout') {
             signOut(auth);
+            setUser(null); // ensure logout for cuentas locales
             return;
         }
         setActiveSection(section);
     };
 
     const handleLogin = (email, password) => {
+        if (email === 'admin' && password === 'si2025') {
+            setUser({ uid: 'local-admin', nombre: 'Admin', rol: 'Admin' });
+            return Promise.resolve();
+        }
         return signInWithEmailAndPassword(auth, email, password);
     };
 

--- a/src/index.css
+++ b/src/index.css
@@ -19,3 +19,47 @@ button {
 .button-primary:hover {
   background-color: #0d3a21;
 }
+
+/* Estilos página de inicio de sesión */
+.login-container {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #4caf50, #2e7d32);
+}
+
+.login-container .form-container {
+  width: 360px;
+  padding: 2rem;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+}
+
+.login-container h2 {
+  text-align: center;
+  margin-bottom: 1.5rem;
+  color: #2e7d32;
+}
+
+.login-container .form-field {
+  margin-bottom: 1rem;
+}
+
+.login-container label {
+  display: block;
+  margin-bottom: 0.25rem;
+  color: #555;
+}
+
+.login-container input {
+  width: 100%;
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.login-container .button-primary {
+  width: 100%;
+}


### PR DESCRIPTION
## Summary
- support a local admin login using the credentials `admin` / `si2025`
- style the login page with a Material-like design
- document the default credentials

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'isexe')*

------
https://chatgpt.com/codex/tasks/task_e_687fe87115048326a4cffa7bb25adb19