### PR TITLE
Improve styling and PDF format

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>Gestion Zoonosis</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   </head>

--- a/src/App.js
+++ b/src/App.js
@@ -374,15 +374,19 @@ const CertificadoVacunacion = ({ vecino, mascota, onBack }) => {
 
     const enviarPDF = () => {
         const doc = new jsPDF();
+        doc.setFillColor(44, 122, 123);
+        doc.rect(0, 0, 210, 20, 'F');
+        doc.setTextColor(255, 255, 255);
         doc.setFontSize(16);
-        doc.text(CERT_TITLE, 105, 20, { align: 'center' });
+        doc.text(CERT_TITLE, 105, 12, { align: 'center' });
+        doc.setTextColor(0, 0, 0);
         doc.setFontSize(12);
-        doc.text(`Dueño: ${vecino.nombre} ${vecino.apellido}`, 20, 40);
-        doc.text(`Domicilio: ${vecino.domicilio}`, 20, 48);
-        doc.text(`Mascota: ${mascota.nombre} - ${mascota.especie} ${mascota.raza}`, 20, 56);
-        doc.text('Vacunas Aplicadas:', 20, 68);
+        doc.text(`Dueño: ${vecino.nombre} ${vecino.apellido}`, 20, 30);
+        doc.text(`Domicilio: ${vecino.domicilio}`, 20, 38);
+        doc.text(`Mascota: ${mascota.nombre} - ${mascota.especie} ${mascota.raza}`, 20, 46);
+        doc.text('Vacunas Aplicadas:', 20, 58);
         vacunas.forEach((v, i) => {
-            const y = 76 + i * 8;
+            const y = 66 + i * 8;
             const fecha = v.fecha.toDate().toLocaleDateString();
             doc.text(`${i + 1}. ${v.motivo} - ${fecha} (${v.sede})`, 26, y);
         });
@@ -630,10 +634,18 @@ const Reportes = () => {
         );
         const snap = await getDocs(q);
         const doc = new jsPDF();
-        doc.text('Reporte de Trabajos', 105, 20, { align: 'center' });
+        doc.setFillColor(44, 122, 123);
+        doc.rect(0, 0, 210, 20, 'F');
+        doc.setTextColor(255, 255, 255);
+        doc.setFontSize(16);
+        doc.text('Reporte de Trabajos', 105, 12, { align: 'center' });
+        doc.setTextColor(0, 0, 0);
+        doc.setFontSize(12);
+        let y = 30;
         snap.docs.forEach((d, i) => {
             const a = d.data();
-            doc.text(`${i + 1}. ${a.tipo} - ${a.motivo} - ${a.sede} - ${a.fecha.toDate().toLocaleDateString()}`, 20, 40 + i * 8);
+            doc.text(`${i + 1}. ${a.tipo} - ${a.motivo} - ${a.sede} - ${a.fecha.toDate().toLocaleDateString()}`, 20, y);
+            y += 8;
         });
         doc.save('reporte.pdf');
         logUserAction(auth.currentUser?.uid, 'exportar reporte', { desde, hasta });

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import './index.css';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(


### PR DESCRIPTION
## Summary
- load global CSS so login form styles show up
- update document title
- style vaccination certificate and report PDFs with color headers

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6880bfbc399883268ccebc0ba1ebd406