### PR TITLE
Add editing for pet history and preview certificates

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -5,7 +5,7 @@ import { getStorage } from 'firebase/storage';
 
 // ▼▼▼ PEGA AQUÍ TU CONFIGURACIÓN DE FIREBASE ▼▼▼
 // Ahora se leen desde variables de entorno para mayor seguridad
-const firebaseConfig = {
+export const firebaseConfig = {
   apiKey: process.env.REACT_APP_FIREBASE_API_KEY,
   authDomain: process.env.REACT_APP_FIREBASE_AUTH_DOMAIN,
   projectId: process.env.REACT_APP_FIREBASE_PROJECT_ID,


### PR DESCRIPTION
## Summary
- allow editing individual attention records for each pet
- show PDF preview before emailing vaccination certificates
- create Firebase auth user with auto-generated password
- export firebase config for use in secondary auth

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6880e07f63188326be25a542c2548c93