### PR TITLE
Fix password change flow and document Firestore indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,19 @@ Luego edite `.env` y coloque los valores proporcionados por Firebase.
 - Usuario: `mfserra@sanisidro.gob.ar`
 - Contraseña: `si2025`
 
+### Índices de Firestore
+
+Algunas consultas usan `collectionGroup` y requieren índices compuestos.
+Si al ejecutar la aplicación ves un error similar a:
+
+```
+FirebaseError: The query requires a COLLECTION_GROUP_ASC index for collection atenciones and field fecha
+```
+
+Ingresa al enlace indicado en el mensaje o crea un índice manualmente desde la
+[consola de Firebase](https://console.firebase.google.com/) para la colección
+`atenciones` ordenada por el campo `fecha`.
+
 ## Available Scripts
 
 Dentro del directorio del proyecto se puede ejecutar:

--- a/src/App.js
+++ b/src/App.js
@@ -793,7 +793,9 @@ const Usuarios = () => {
                 const apps = getApps();
                 const secondary = apps.find(a => a.name === 'Secondary') || initializeApp(firebaseConfig, 'Secondary');
                 const secondaryAuth = getAuth(secondary);
-                await signInWithEmailAndPassword(secondaryAuth, u.email, u.password);
+                const currentPassword = u.password || prompt('Ingrese la contraseña actual para ' + u.email);
+                if (!currentPassword) throw new Error('missing-password');
+                await signInWithEmailAndPassword(secondaryAuth, u.email, currentPassword);
                 await deleteUser(secondaryAuth.currentUser);
                 await signOut(secondaryAuth);
             } catch (err) {
@@ -811,7 +813,9 @@ const Usuarios = () => {
             const apps = getApps();
             const secondary = apps.find(a => a.name === 'Secondary') || initializeApp(firebaseConfig, 'Secondary');
             const secondaryAuth = getAuth(secondary);
-            await signInWithEmailAndPassword(secondaryAuth, u.email, u.password);
+            const currentPassword = u.password || prompt('Ingrese la contraseña actual para ' + u.email);
+            if (!currentPassword) throw new Error('missing-password');
+            await signInWithEmailAndPassword(secondaryAuth, u.email, currentPassword);
             await updatePassword(secondaryAuth.currentUser, nueva);
             await signOut(secondaryAuth);
             await updateDoc(doc(db, 'usuarios', u.id), { password: nueva });


### PR DESCRIPTION
## Summary
- handle user actions when password is missing by prompting for the current one
- document required Firestore indexes in README

## Testing
- `CI=true npm test --silent -- --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_68811216cc248326a4147e820cf01a97