### PR TITLE
Add fallback admin login

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Luego edite `.env` y coloque los valores proporcionados por Firebase.
 
 ### Usuario administrador
 - Usuario: `mfserra@sanisidro.gob.ar`
+- Usuario alternativo: `cfernandezcastro.si@gmail.com`
 - Contraseña: `si2025`
 
 ### Índices de Firestore

--- a/src/App.js
+++ b/src/App.js
@@ -1131,11 +1131,21 @@ const App = () => {
     };
 
     const handleLogin = (email, password) => {
-        if (email === 'mfserra@sanisidro.gob.ar' && password === 'si2025') {
-            setUser({ uid: 'local-admin', nombre: 'Admin', rol: 'Admin' });
-            return Promise.resolve();
-        }
-        return signInWithEmailAndPassword(auth, email, password);
+        // Primero intentamos autenticar con Firebase
+        return signInWithEmailAndPassword(auth, email, password).catch(err => {
+            // Si el usuario no existe en Firebase permitimos login local para cuentas predefinidas
+            const localAdmins = [
+                'mfserra@sanisidro.gob.ar',
+                'cfernandezcastro.si@gmail.com',
+            ];
+
+            if (err.code === 'auth/user-not-found' && localAdmins.includes(email) && password === 'si2025') {
+                setUser({ uid: 'local-admin', nombre: 'Admin', rol: 'Admin' });
+                return Promise.resolve();
+            }
+
+            throw err;
+        });
     };
 
     if (loading) return <div className="loading-screen">Cargando aplicación...</div>;


### PR DESCRIPTION
## Summary
- allow both admin emails to log in via Firebase
- fall back to local auth if account doesn't exist

## Testing
- `CI=true npm test --silent -- -u`


------
https://chatgpt.com/codex/tasks/task_e_68816b0875748326a1c45b45294a3943