### PR TITLE
Improve local admin login fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ Luego edite `.env` y coloque los valores proporcionados por Firebase.
 - Usuario alternativo: `cfernandezcastro.si@gmail.com`
 - Contraseña: `si2025`
 
+Estas credenciales también permiten iniciar sesión de forma local incluso si la
+configuración de Firebase no está disponible.
+
 ### Índices de Firestore
 
 Algunas consultas usan `collectionGroup` y requieren índices compuestos.

--- a/src/App.js
+++ b/src/App.js
@@ -1136,14 +1136,14 @@ const App = () => {
 
     const handleLogin = (email, password) => {
         // Primero intentamos autenticar con Firebase
-        return signInWithEmailAndPassword(auth, email, password).catch(err => {
-            // Si el usuario no existe en Firebase permitimos login local para cuentas predefinidas
-            const localAdmins = [
-                'mfserra@sanisidro.gob.ar',
-                'cfernandezcastro.si@gmail.com',
-            ];
+        const localAdmins = [
+            'mfserra@sanisidro.gob.ar',
+            'cfernandezcastro.si@gmail.com',
+        ];
 
-            if (err.code === 'auth/user-not-found' && localAdmins.includes(email) && password === 'si2025') {
+        return signInWithEmailAndPassword(auth, email, password).catch(err => {
+            // Si no es posible autenticarse (por cualquier motivo) permitimos login local
+            if (localAdmins.includes(email) && password === 'si2025') {
                 setUser({ uid: 'local-admin', nombre: 'Admin', rol: 'Admin' });
                 return Promise.resolve();
             }


### PR DESCRIPTION
## Summary
- allow local admin login when Firebase login fails for any reason
- document local login functionality in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6881734bafe48326901a50194e2e6b51