### PR TITLE
Temporarily hide user and logs sections

### DIFF
--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -21,8 +21,8 @@ const Sidebar = ({ onSelect, activeSection, user, open, onClose }) => {
           <div className="sidebar-section-divider">
             <p className="sidebar-section-title">Administración</p>
             <SidebarLink icon="fa-user-md" text="Veterinarios" section="veterinarios" activeSection={activeSection} onSelect={handleSelect} />
-            <SidebarLink icon="fa-user-shield" text="Gestión de Usuarios" section="usuarios" activeSection={activeSection} onSelect={handleSelect} />
-            <SidebarLink icon="fa-file-alt" text="Logs" section="logs" activeSection={activeSection} onSelect={handleSelect} />
+            {/*<SidebarLink icon="fa-user-shield" text="Gestión de Usuarios" section="usuarios" activeSection={activeSection} onSelect={handleSelect} />*/}
+            {/*<SidebarLink icon="fa-file-alt" text="Logs" section="logs" activeSection={activeSection} onSelect={handleSelect} />*/}
           </div>
         )}
       </nav>


### PR DESCRIPTION
## Summary
- hide sidebar links for User Management and Logs
- comment out rendering those sections
- update permission options accordingly

## Testing
- `npm test --silent -- -u --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_688175e98cec8326957c70c345e9c589